### PR TITLE
Updated RestSharp NuGet version

### DIFF
--- a/Source/PagerDuty.Net.Tests/PagerDuty.Net.Tests.csproj
+++ b/Source/PagerDuty.Net.Tests/PagerDuty.Net.Tests.csproj
@@ -41,8 +41,9 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp">
-      <HintPath>..\packages\RestSharp.104.1\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/Source/PagerDuty.Net.Tests/packages.config
+++ b/Source/PagerDuty.Net.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
-  <package id="RestSharp" version="104.1" targetFramework="net45" />
+  <package id="RestSharp" version="105.1.0" targetFramework="net40" />
 </packages>

--- a/Source/PagerDuty.Net/PagerDuty.Net.csproj
+++ b/Source/PagerDuty.Net/PagerDuty.Net.csproj
@@ -33,8 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp">
-      <HintPath>..\packages\RestSharp.104.1\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/PagerDuty.Net/PagerDutyAPI.cs
+++ b/Source/PagerDuty.Net/PagerDutyAPI.cs
@@ -31,7 +31,7 @@ namespace PagerDuty.Net {
         /// <param name="url">The API endpoint you are hitting</param>
         /// <returns></returns>
         protected virtual IRestClient GetClient(string url) {
-            var client = new RestClient() { Timeout = this.Timeout, BaseUrl = "https://" + Subdomain + ".pagerduty.com/api" + url };
+            var client = new RestClient() { Timeout = this.Timeout, BaseUrl = new Uri("https://" + Subdomain + ".pagerduty.com/api" + url) };
             client.AddDefaultParameter(new Parameter { Name = "Authorization", Value = "Token token=" + this.AccessToken, Type = ParameterType.HttpHeader });
             return client;
         }
@@ -372,7 +372,7 @@ namespace PagerDuty.Net {
         /// <returns></returns>
         private IntegrationResponse PostIntegrationRequest(object request) {
             var integrationUrl = "https://events.pagerduty.com/generic/2010-04-15/create_event.json";
-            var client = new RestClient() { Timeout = this.Timeout, BaseUrl = integrationUrl };
+            var client = new RestClient() { Timeout = this.Timeout, BaseUrl = new Uri(integrationUrl) };
             var req = this.GetRequest();
             req.Method = Method.POST;
 

--- a/Source/PagerDuty.Net/packages.config
+++ b/Source/PagerDuty.Net/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="104.1" targetFramework="net45" />
+  <package id="RestSharp" version="105.1.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This PR simply updates the RestSharp NuGet version and updates the affected code.

They introduced a breaking change that causes users of the newer RestSharp lib to not work properly.