### PR TITLE
Fix for GetNotesForIncident method

### DIFF
--- a/Source/PagerDuty.Net.Tests/PagerDutyAPITests.cs
+++ b/Source/PagerDuty.Net.Tests/PagerDutyAPITests.cs
@@ -163,11 +163,11 @@ namespace PagerDuty.Net.Tests {
         [TestMethod]
         public void GetIncidentNotes_PerformsCorrectRequest() {
             //Setup
-            var response = new RestResponse<List<Note>> { Data = new List<Note>() };
+            var response = new RestResponse<Notes> { Data = new Notes() };
             var restReq = new Mock<IRestRequest>();
 
             var restClient = new Mock<RestClient>();
-            restClient.Setup(x => x.Execute<List<Note>>(It.IsAny<IRestRequest>())).Returns(response);
+            restClient.Setup(x => x.Execute<Notes>(It.IsAny<IRestRequest>())).Returns(response);
 
             var api = new MockPagerDutyAPI(restClient.Object, restReq.Object, "domain", "token");
             api.GetNotesForIncident("EXAMPLE");

--- a/Source/PagerDuty.Net/Models/Notes.cs
+++ b/Source/PagerDuty.Net/Models/Notes.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PagerDuty.Net
+{
+  [Serializable()]
+  public class Notes
+  {
+    public List<Note> notes { get; set; }
+  }
+}

--- a/Source/PagerDuty.Net/PagerDuty.Net.csproj
+++ b/Source/PagerDuty.Net/PagerDuty.Net.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Models\LogEntry.cs" />
     <Compile Include="Models\LogEntryResponse.cs" />
     <Compile Include="Models\Note.cs" />
+    <Compile Include="Models\Notes.cs" />
     <Compile Include="Models\Notification.cs" />
     <Compile Include="Models\Rollup.cs" />
     <Compile Include="Models\Schedule.cs" />

--- a/Source/PagerDuty.Net/PagerDuty.Net.csproj
+++ b/Source/PagerDuty.Net/PagerDuty.Net.csproj
@@ -33,9 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net4\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/PagerDuty.Net/PagerDutyAPI.cs
+++ b/Source/PagerDuty.Net/PagerDutyAPI.cs
@@ -257,13 +257,13 @@ namespace PagerDuty.Net {
             var client = this.GetClient("/v1/incidents/"+id+"/notes");
             var req = this.GetRequest();
 
-            var resp = client.Execute<List<Note>>(req);
+            var resp = client.Execute<Notes>(req);
 
             if (resp.Data == null) {
                 throw new PagerDutyAPIException(resp);
             }
 
-            return resp.Data;
+            return resp.Data.notes;
         }
 
         /// <summary>

--- a/Source/PagerDuty.Net/packages.config
+++ b/Source/PagerDuty.Net/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net40" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The method was not able to deserialize the response from PagerDuty as there is a notes root node in the JSON. I've added a new class to represent a list of Notes and it now works as expected.

Also took the opportunity to update the RestSharp dependency to the latest version.